### PR TITLE
Update dependencies; change release plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ you advice on the proposed changes. If the changes are minor, then feel free
 to make them without discussion.
 
 ## Deploying
-https://github.com/nebula-plugins/nebula-release-plugin
-https://github.com/nebula-plugins/nebula-publishing-plugin
+https://github.com/researchgate/gradle-release
+https://github.com/gradle-nexus/publish-plugin/
 
 
 1. Add the following to your `~/.gradle/gradle.properties`:
@@ -19,14 +19,13 @@ https://github.com/nebula-plugins/nebula-publishing-plugin
 signing.keyId=XXXXXXXX
 signing.password=<key password, if one exists>
 signing.secretKeyRingFile=/Users/me/.gnupg/secring.gpg
-centralUsername=<sonatype username>
-centralPassword=<sonatype password>
+sonatypeUsername=<sonatype username>
+sonatypePassword=<sonatype password>
 ```
 
 1. Start a new branch for your release. Name it according to the release's semantic version number: `v#.#.#`.
-1. Run `./gradlew final`. This will create a git tag and push it to GitHub.
-  * By default, `final` increments the minor version in the project's semantic version.
-  * To bump the major or patch version: `./gradlew final -Prelease.scope=(major|patch)]`.
-1. Run `./gradlew publish -Prelease.useLastTag=true`. This uploads artifacts to a staging repository to be synced with Maven Central.
+1. Run `./gradlew :SpokestackTray:release`. This will prompt for version information, create a git tag, push it to GitHub, and upload build artifacts to Sonatype's OSSRH server.
 1. PR your release branch on GitHub.
 1. Add release notes for the tag on GitHub.
+
+Note that the project is configured to sign the git tag, so you may have problems if your gitconfig does not include signing information.

--- a/SpokestackTray/build.gradle
+++ b/SpokestackTray/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'kotlin-android-extensions'
     id 'com.gladed.androidgitversion' version '0.4.13'
 }
 
@@ -45,7 +44,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.0-rc01'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 
     // Spokestack dependencies
@@ -55,7 +54,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
 
     // TTS
-    implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-common-java8:2.3.0'
     implementation "androidx.media:media:$androidx_media_version"
     implementation "com.google.android.exoplayer:exoplayer-core:$exoplayer_version"
 

--- a/SpokestackTray/build.gradle
+++ b/SpokestackTray/build.gradle
@@ -65,4 +65,4 @@ dependencies {
 }
 
 // deployment
-apply from: "$rootDir/gradle/publish.gradle"
+apply from: "$rootDir/gradle/release.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        kotlin_version = "1.4.30"
+        kotlin_version = "1.4.31"
         dokka_version = "1.4.10"
         jfrog_plugin_version = "1.8.5"
         bintray_plugin_version = "8.5.0"
         release_plugin_version = "15.3.0"
         publishing_plugin_version = "17.1.0"
-        spokestack_version="11.0.2"
+        spokestack_version="11.0.3"
         androidx_media_version="1.2.1"
         exoplayer_version="2.11.7"
         tensorflow_version="2.3.0"
@@ -18,7 +18,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0-alpha15'
+        classpath 'com.android.tools.build:gradle:4.2.0-beta05'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // deployment

--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,18 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // deployment
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:${jfrog_plugin_version}"
-        classpath "com.netflix.nebula:nebula-release-plugin:${release_plugin_version}"
+        classpath 'net.researchgate:gradle-release:2.8.1'
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"
+    }
+}
+
+plugins {
+    id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
+}
+
+nexusPublishing {
+    repositories {
+        sonatype()
     }
 }
 
@@ -40,4 +49,3 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
-apply plugin: "nebula.release"

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 30
@@ -31,10 +30,10 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.1'
+    implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
-    testImplementation 'junit:junit:4.13'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
+apply plugin: 'net.researchgate.release'
 
 dokkaJavadoc {
     outputDirectory.set(file("$buildDir/javadoc"))
@@ -24,28 +25,17 @@ dokkaJavadoc {
 }
 
 task androidJavadocsJar(type: Jar, dependsOn: dokkaJavadoc) {
-    archiveClassifier = 'javadoc'
+    getArchiveClassifier().set('javadoc')
     from dokkaJavadoc.outputDirectory
 }
 
 task androidSourcesJar(type: Jar) {
-    archiveClassifier = 'sources'
+    getArchiveClassifier().set('sources')
     from android.sourceSets.main.java.srcDirs
 }
 
 afterEvaluate {
     publishing {
-        repositories {
-            maven {
-                name = "central"
-                def snapshotUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-                def releaseUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-                def ver = rootProject.version.toString()
-                url = ver.contains("dev") ? snapshotUrl : releaseUrl
-                credentials(PasswordCredentials)
-            }
-        }
-
         publications {
             tray(MavenPublication) {
                 from components.release
@@ -87,3 +77,14 @@ afterEvaluate {
         }
     }
 }
+
+release {
+    git {
+        requireBranch = '/v?[0-9]+.[0-9]+.[0-9]+/'
+    }
+}
+
+afterReleaseBuild.dependsOn(
+        ':SpokestackTray:publishToSonatype',
+        ':closeAndReleaseSonatypeStagingRepository'
+)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip


### PR DESCRIPTION
The new Gradle plugins should allow us to make releasing a single step on the command line and auto-close the Sonatype staging repositories after upload.