### PR TITLE
Revert "remove jcenter repository"

### DIFF
--- a/SpokestackTray/build.gradle
+++ b/SpokestackTray/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
     // Spokestack dependencies
     api "io.spokestack:spokestack-android:$spokestack_version"
-    implementation "org.tensorflow:tensorflow-lite:2.4.0"
+    implementation "org.tensorflow:tensorflow-lite:2.3.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.recyclerview:recyclerview:1.2.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     repositories {
         mavenCentral()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0-rc01'
@@ -39,6 +40,7 @@ allprojects {
     repositories {
         mavenCentral()
         google()
+        jcenter()
     }
 }
 


### PR DESCRIPTION
We need to restore JCenter for now to allow docs to build while dokka [migrates to Maven Central](https://github.com/Kotlin/dokka/issues/41).