### PR TITLE
fix: speech event logging no longer appears as NLU

### DIFF
--- a/SpokestackTray/src/main/java/io/spokestack/tray/SpokestackTray.kt
+++ b/SpokestackTray/src/main/java/io/spokestack/tray/SpokestackTray.kt
@@ -588,23 +588,30 @@ class SpokestackTray constructor(
         }
 
         override fun speechEvent(event: SpeechContext.Event, speechContext: SpeechContext) {
+            var logMsg: String? = null
             when (event) {
                 SpeechContext.Event.ACTIVATE -> {
-                    onTrace(EventTracer.Level.PERF, "ACTIVATE")
+                    logMsg = event.name
                     setOpen(true)
                 }
                 SpeechContext.Event.PARTIAL_RECOGNIZE, SpeechContext.Event.RECOGNIZE -> {
                     displayTranscript(speechContext)
                 }
                 SpeechContext.Event.TIMEOUT -> {
-                    onTrace(EventTracer.Level.PERF, "TIMEOUT")
+                    logMsg = event.name
                     setOpen(false)
                 }
-                SpeechContext.Event.ERROR -> dispatchError(speechContext.error)
-                SpeechContext.Event.TRACE -> onTrace(EventTracer.Level.PERF, speechContext.message)
                 SpeechContext.Event.DEACTIVATE -> {
-                    onTrace(EventTracer.Level.PERF, "DEACTIVATE")
+                    logMsg = event.name
                     setListening(false)
+                }
+                else -> return  // noop; traces and errors are handled by the superclass
+            }
+
+            // send PERF log for some events if configured to receive them
+            logMsg?.let {
+                if (config.logLevel <= EventTracer.Level.PERF.value()) {
+                    trace(SpokestackModule.SPEECH_PIPELINE, it)
                 }
             }
         }

--- a/example/src/main/java/io/spokestack/tray/example/MainActivity.kt
+++ b/example/src/main/java/io/spokestack/tray/example/MainActivity.kt
@@ -12,6 +12,7 @@ class MainActivity : TrayActivity(), SpokestackTrayListener {
 
     override fun getTrayConfig(): TrayConfig {
         return TrayConfig.Builder()
+            // substitute your own credentials
             .credentials(
                 "f0bc990c-e9db-4a0c-a2b1-6a6395a3d97e",
                 "5BD5483F573D691A15CFA493C1782F451D4BD666E39A9E7B2EBE287E6A72C6B6"
@@ -56,6 +57,7 @@ class MainActivity : TrayActivity(), SpokestackTrayListener {
     }
 
     override fun onError(error: Throwable) {
+        error.printStackTrace()
         println("ERROR: ${error.localizedMessage}")
     }
 


### PR DESCRIPTION
The `onTrace` method currently called in the tray's speech event listener reports events from the NLU module. The correct method to use here is `trace`. The intended log level of `PERF` for these events is maintained via an explicit check in the event handler.