### PR TITLE
feat: Rasa NLU/dialogue management in config

### DIFF
--- a/SpokestackTray/src/main/java/io/spokestack/tray/SpokestackFactory.kt
+++ b/SpokestackTray/src/main/java/io/spokestack/tray/SpokestackFactory.kt
@@ -54,7 +54,11 @@ object SpokestackFactory {
         if (trayConfig.nluURL != null) {
             ensureNlu(trayConfig, builder, context)
         } else {
-            builder.withoutNlu()
+            if (trayConfig.rasaOssURL != null) {
+                builder.useRasaOpenSource(trayConfig.rasaOssURL)
+            } else {
+                builder.withoutNlu()
+            }
         }
         return builder
     }

--- a/SpokestackTray/src/main/java/io/spokestack/tray/SpokestackTray.kt
+++ b/SpokestackTray/src/main/java/io/spokestack/tray/SpokestackTray.kt
@@ -23,6 +23,7 @@ import io.spokestack.spokestack.SpeechContext
 import io.spokestack.spokestack.Spokestack
 import io.spokestack.spokestack.SpokestackAdapter
 import io.spokestack.spokestack.SpokestackModule
+import io.spokestack.spokestack.dialogue.DialogueEvent
 import io.spokestack.spokestack.nlu.NLUResult
 import io.spokestack.spokestack.tts.SynthesisRequest
 import io.spokestack.spokestack.tts.TTSEvent
@@ -545,8 +546,22 @@ class SpokestackTray constructor(
             }
 
         override fun nluResult(result: NLUResult) {
+            // if there's a dialogue manager, let it handle generating the
+            // prompts; otherwise, defer to the listener's NLU handling logic
+            if (spokestack.dialogueManager == null) {
+                try {
+                    listener?.onClassification(result)?.let {
+                        say(it)
+                    }
+                } catch (e: Exception) {
+                    listener?.onError(e)
+                }
+            }
+        }
+
+        override fun onDialogueEvent(event: DialogueEvent) {
             try {
-                listener?.onClassification(result)?.let {
+                listener?.onDialogueEvent(event)?.let {
                     say(it)
                 }
             } catch (e: Exception) {

--- a/SpokestackTray/src/main/java/io/spokestack/tray/SpokestackTrayListener.kt
+++ b/SpokestackTray/src/main/java/io/spokestack/tray/SpokestackTrayListener.kt
@@ -1,7 +1,7 @@
 package io.spokestack.tray
 
+import io.spokestack.spokestack.dialogue.DialogueEvent
 import io.spokestack.spokestack.nlu.NLUResult
-import io.spokestack.spokestack.tts.TTSEvent
 import io.spokestack.spokestack.util.EventTracer
 
 /**
@@ -29,9 +29,19 @@ interface SpokestackTrayListener {
      * Spokestack's NLU classified an utterance.
      *
      * @param result The classification result.
-     * @return A string representing the application's response to the user utterance.
+     * @return A prompt representing the application's response to the user utterance.
      */
     fun onClassification(result: NLUResult): Prompt? {
+        return null
+    }
+
+    /**
+     * Spokestack's dialogue manager emitted an event.
+     *
+     * @param event The dialogue event.
+     * @return A prompt representing the application's response to the user utterance.
+     */
+    fun onDialogueEvent(event: DialogueEvent): Prompt? {
         return null
     }
 

--- a/SpokestackTray/src/main/java/io/spokestack/tray/TrayConfig.kt
+++ b/SpokestackTray/src/main/java/io/spokestack/tray/TrayConfig.kt
@@ -47,7 +47,7 @@ class TrayConfig private constructor(builder: Builder) {
 
     /**
      * Synthesis mode for TTS. This defaults to `TEXT` and should only be changed if
-     * the messages you return to the Tray in [VoicePrompt]s are in SSML or Speech
+     * the messages you return to the Tray in [Prompt]s are in SSML or Speech
      * Markdown format.
      */
     val ttsMode: Mode = builder.ttsMode
@@ -91,6 +91,16 @@ class TrayConfig private constructor(builder: Builder) {
     val nluURL: String? = builder.nluURL
 
     /**
+     * The URL to the Rasa Open Source server. If this is set, Spokestack will use Rasa Core
+     * for both NLU and dialogue management.
+     *
+     * For production use, this endpoint should be secured. See the documentation
+     * for [io.spokestack.spokestack.rasa.RasaOpenSourceNLU] for descriptions of authentication
+     * methods you can specify using [Builder.withProperty].
+     */
+    val rasaOssURL: String? = builder.rasaOssURL
+
+    /**
      * Whether wakeword and NLU models should be forcibly (re-)downloaded on launch.
      */
     val refreshModels: Boolean = builder.refreshModels
@@ -132,6 +142,7 @@ class TrayConfig private constructor(builder: Builder) {
         internal var logLevel: Int = EventTracer.Level.NONE.value(),
         internal var wakewordModelURL: String? = null,
         internal var nluURL: String? = null,
+        internal var rasaOssURL: String? = null,
         internal var refreshModels: Boolean = false,
         internal var editTranscript: ((String) -> String)? = null,
         internal var listener: SpokestackTrayListener? = null,
@@ -240,6 +251,18 @@ class TrayConfig private constructor(builder: Builder) {
          * download multiple files.
          */
         fun nluURL(value: String?) = apply { this.nluURL = value }
+
+        /**
+         * Set the URL to a Rasa Open Source server. If set, [nluURL] will be ignored,
+         * as Rasa Open Source will handle both NLU and dialogue management.
+         *
+         * For production use, this endpoint should be secured. See the documentation
+         * for [io.spokestack.spokestack.rasa.RasaOpenSourceNLU] for descriptions of authentication
+         * methods you can specify with [withProperty].
+         *
+         * @param value The URL to the Rasa Open Source server's REST endpoint.
+         */
+        fun rasaOssUrl(value: String?) = apply { this.rasaOssURL = value }
 
         /**
          * Set whether wakeword and NLU models should be unconditionally redownloaded on

--- a/example/src/main/java/io/spokestack/tray/example/MainActivity.kt
+++ b/example/src/main/java/io/spokestack/tray/example/MainActivity.kt
@@ -18,7 +18,7 @@ class MainActivity : TrayActivity(), SpokestackTrayListener {
                 "5BD5483F573D691A15CFA493C1782F451D4BD666E39A9E7B2EBE287E6A72C6B6"
             )
             .wakewordModelURL("https://d3dmqd7cy685il.cloudfront.net/model/wake/spokestack")
-            .nluURL("https://d3dmqd7cy685il.cloudfront.net/nlu/production/shared/XtASJqxkO6UwefOzia-he2gnIMcBnR2UCF-VyaIy-OI")
+            .nluURL("https://s.spokestack.io/u/7fYxV")
             .logLevel(EventTracer.Level.PERF.value())
             .withListener(this)
             .greeting(greeting)

--- a/versions.properties
+++ b/versions.properties
@@ -1,1 +1,1 @@
-spokestack_version=11.2.0
+spokestack_version=11.3.0


### PR DESCRIPTION
This adds a configuration option and event handling for Spokestack's Rasa integration. When using a dialogue manager, the tray listener is responsible for deciding whether a given dialogue event should be communicated to the user via a `Prompt` or should produce some other change to the app.

Closes #29 by updating the core Spokestack library to the latest version.