### PR TITLE
fix: eliminate auto-scroll flashing in the message stream

### DIFF
--- a/SpokestackTray/src/main/java/io/spokestack/tray/SpokestackTray.kt
+++ b/SpokestackTray/src/main/java/io/spokestack/tray/SpokestackTray.kt
@@ -433,7 +433,7 @@ class SpokestackTray constructor(
 
         // observe messages for changes
         state.liveData().observe(viewLifecycleOwner, { messages ->
-            viewAdapter.notifyDataSetChanged()
+            viewAdapter.notifyItemChanged(messages.size - 1)
             binding.messageStream.scrollToPosition(messages.size - 1)
         })
 

--- a/SpokestackTray/src/main/java/io/spokestack/tray/SpokestackTray.kt
+++ b/SpokestackTray/src/main/java/io/spokestack/tray/SpokestackTray.kt
@@ -431,11 +431,15 @@ class SpokestackTray constructor(
         val viewAdapter = MessageAdapter(requireContext())
         viewAdapter.submitList(state.messages)
 
+        val observer = { messages: List<Message> ->
+            val lastMessage = messages.size - 1
+            viewAdapter.notifyItemChanged(lastMessage)
+            binding.messageStream.scrollToPosition(lastMessage)
+        }
+        viewAdapter.observer = observer
+
         // observe messages for changes
-        state.liveData().observe(viewLifecycleOwner, { messages ->
-            viewAdapter.notifyItemChanged(messages.size - 1)
-            binding.messageStream.scrollToPosition(messages.size - 1)
-        })
+        state.liveData().observe(viewLifecycleOwner, observer)
 
         binding.messageStream.apply {
             setHasFixedSize(true)

--- a/SpokestackTray/src/main/java/io/spokestack/tray/message/MessageAdapter.kt
+++ b/SpokestackTray/src/main/java/io/spokestack/tray/message/MessageAdapter.kt
@@ -20,6 +20,7 @@ class MessageAdapter(context: Context) :
 
     private var startPosition = -1
     private val bubbleAnimation = AnimationUtils.loadAnimation(context, R.anim.item_enter)
+    var observer: ((List<Message>) -> Unit)? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val msgView: LinearLayout
@@ -70,13 +71,14 @@ class MessageAdapter(context: Context) :
 
     class BubbleViewHolder(val msgLayout: LinearLayout) : RecyclerView.ViewHolder(msgLayout)
 
-    class MessageBubbleTarget(private val textView: TextView) :
+    inner class MessageBubbleTarget(private val textView: TextView) :
         CustomTarget<Drawable>(SIZE_ORIGINAL, SIZE_ORIGINAL) {
         override fun onResourceReady(
             resource: Drawable,
             transition: Transition<in Drawable>?
         ) {
             textView.setCompoundDrawablesWithIntrinsicBounds(null, null, null, resource)
+            observer?.invoke(currentList)
         }
 
         override fun onLoadCleared(placeholder: Drawable?) {


### PR DESCRIPTION
This eliminates visual disruption due to recalculating the layout every time a partial ASR transcript is received. Now only the last message bubble is updated, as intended.

It also adds a fix for scrolling to the bottom of a newly loaded image instead of the bottom of the message bubble pre-load.